### PR TITLE
 feat: add disablePadIndex and zeroBasedArrayIndex option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ write //set common write variable to true
 forceIndex //instead of trying to find names for array entries, use the index as the name.
 Otherweise the value of a key with id, name, label, labelText will use a name. This is key overriden by preferedArrayName
 
+padArrayIndex //pad index numbers with 0, e.g. 01, 02, 03, ...
+
+zeroBasedArrayIndex //start array index from 0
+
 preferedArrayName //set key to use this as an array entry name
 
 preferedArrayDec //set key to use this as an array entry description

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ write //set common write variable to true
 forceIndex //instead of trying to find names for array entries, use the index as the name.
 Otherweise the value of a key with id, name, label, labelText will use a name. This is key overriden by preferedArrayName
 
-padArrayIndex //pad index numbers with 0, e.g. 01, 02, 03, ...
+disablePadIndex //disables padding of array index numbers if forceIndex = true
 
-zeroBasedArrayIndex //start array index from 0
+zeroBasedArrayIndex //start array index from 0 if forceIndex = true
 
 preferedArrayName //set key to use this as an array entry name
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,6 +1,8 @@
 type Options = {
     write?: boolean;
     forceIndex?: boolean;
+    padArrayIndex?: boolean;
+    zeroBasedArrayIndex?: boolean;
     channelName?: string;
     preferedArrayName?: string;
     preferedArrayDesc?: string;
@@ -30,6 +32,8 @@ declare class Json2iob {
      * @param {Options} [options={}] - The parsing options.
      * @param {boolean} [options.write] - Activate write for all states.
      * @param {boolean} [options.forceIndex] - Instead of trying to find names for array entries, use the index as the name.
+     * @param {boolean} [options.padArrayIndex] - Pad index numbers with 0, e.g. 01, 02, 03, ...
+     * @param {boolean} [options.zeroBasedArrayIndex] - Start array index from 0
      * @param {string} [options.channelName] - Set name of the root channel.
      * @param {string} [options.preferedArrayName] - Set key to use this as an array entry name.
      * @param {string} [options.preferedArrayDesc] - Set key to use this as an array entry description.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,7 +1,7 @@
 type Options = {
     write?: boolean;
     forceIndex?: boolean;
-    padArrayIndex?: boolean;
+    disablePadIndex?: boolean;
     zeroBasedArrayIndex?: boolean;
     channelName?: string;
     preferedArrayName?: string;
@@ -32,8 +32,8 @@ declare class Json2iob {
      * @param {Options} [options={}] - The parsing options.
      * @param {boolean} [options.write] - Activate write for all states.
      * @param {boolean} [options.forceIndex] - Instead of trying to find names for array entries, use the index as the name.
-     * @param {boolean} [options.padArrayIndex] - Pad index numbers with 0, e.g. 01, 02, 03, ...
-     * @param {boolean} [options.zeroBasedArrayIndex] - Start array index from 0
+     * @param {boolean} [options.disablePadIndex] - Disables padding of array index numbers if forceIndex = true
+     * @param {boolean} [options.zeroBasedArrayIndex] - Start array index from 0 if forceIndex = true
      * @param {string} [options.channelName] - Set name of the root channel.
      * @param {string} [options.preferedArrayName] - Set key to use this as an array entry name.
      * @param {string} [options.preferedArrayDesc] - Set key to use this as an array entry description.

--- a/dist/index.js
+++ b/dist/index.js
@@ -28,8 +28,8 @@ class Json2iob {
      * @param {Options} [options={}] - The parsing options.
      * @param {boolean} [options.write] - Activate write for all states.
      * @param {boolean} [options.forceIndex] - Instead of trying to find names for array entries, use the index as the name.
-     * @param {boolean} [options.padArrayIndex] - Pad index numbers with 0, e.g. 01, 02, 03, ...
-     * @param {boolean} [options.zeroBasedArrayIndex] - Start array index from 0
+     * @param {boolean} [options.disablePadIndex] - Disables padding of array index numbers if forceIndex = true
+     * @param {boolean} [options.zeroBasedArrayIndex] - Start array index from 0 if forceIndex = true
      * @param {string} [options.channelName] - Set name of the root channel.
      * @param {string} [options.preferedArrayName] - Set key to use this as an array entry name.
      * @param {string} [options.preferedArrayDesc] - Set key to use this as an array entry description.
@@ -402,7 +402,7 @@ class Json2iob {
                     if (options.zeroBasedArrayIndex === true) {
                         indexNumber -= 1;
                     }
-                    index = `${(options.padArrayIndex === true || options.padArrayIndex === undefined) && indexNumber < 10 ? "0" : ""}${indexNumber}`;
+                    index = `${options.disablePadIndex === false && indexNumber < 10 ? "0" : ""}${indexNumber}`;
                     arrayPath = key + index;
                 }
                 //special case array with 2 string objects

--- a/dist/index.js
+++ b/dist/index.js
@@ -402,7 +402,13 @@ class Json2iob {
                     if (options.zeroBasedArrayIndex === true) {
                         indexNumber -= 1;
                     }
-                    index = `${options.disablePadIndex === false && indexNumber < 10 ? "0" : ""}${indexNumber}`;
+                    if (options.disablePadIndex) {
+                        index = indexNumber.toString();
+                    }
+                    else if (indexNumber < 10) {
+                        // reassign index in case zeroBasedarrayIndex is enabled
+                        index = `0${indexNumber}`;
+                    }
                     arrayPath = key + index;
                 }
                 //special case array with 2 string objects

--- a/dist/index.js
+++ b/dist/index.js
@@ -28,6 +28,8 @@ class Json2iob {
      * @param {Options} [options={}] - The parsing options.
      * @param {boolean} [options.write] - Activate write for all states.
      * @param {boolean} [options.forceIndex] - Instead of trying to find names for array entries, use the index as the name.
+     * @param {boolean} [options.padArrayIndex] - Pad index numbers with 0, e.g. 01, 02, 03, ...
+     * @param {boolean} [options.zeroBasedArrayIndex] - Start array index from 0
      * @param {string} [options.channelName] - Set name of the root channel.
      * @param {string} [options.preferedArrayName] - Set key to use this as an array entry name.
      * @param {string} [options.preferedArrayDesc] - Set key to use this as an array entry description.
@@ -303,10 +305,9 @@ class Json2iob {
                     this.adapter.log.debug("Cannot extract empty: " + path + "." + key + "." + index);
                     continue;
                 }
-                // @ts-ignore
-                index = parseInt(index) + 1;
-                // @ts-ignore
-                if (index < 10) {
+                let indexNumber = parseInt(index) + 1;
+                index = indexNumber.toString();
+                if (indexNumber < 10) {
                     index = "0" + index;
                 }
                 if (options.autoCast && typeof arrayElement === "string" && this._isJsonString(arrayElement)) {
@@ -398,6 +399,10 @@ class Json2iob {
                     arrayPath = arrayElement[options.preferedArrayName].toString().replace(/\./g, "");
                 }
                 if (options.forceIndex) {
+                    if (options.zeroBasedArrayIndex === true) {
+                        indexNumber -= 1;
+                    }
+                    index = `${options.padArrayIndex === true && indexNumber < 10 ? "0" : ""}${indexNumber}`;
                     arrayPath = key + index;
                 }
                 //special case array with 2 string objects

--- a/dist/index.js
+++ b/dist/index.js
@@ -402,7 +402,7 @@ class Json2iob {
                     if (options.zeroBasedArrayIndex === true) {
                         indexNumber -= 1;
                     }
-                    index = `${options.padArrayIndex === true && indexNumber < 10 ? "0" : ""}${indexNumber}`;
+                    index = `${(options.padArrayIndex === true || options.padArrayIndex === undefined) && indexNumber < 10 ? "0" : ""}${indexNumber}`;
                     arrayPath = key + index;
                 }
                 //special case array with 2 string objects

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ import JSONbig from "json-bigint";
 type Options = {
   write?: boolean; // Activate write for all states.
   forceIndex?: boolean; // Instead of trying to find names for array entries, use the index as the name.
-  padArrayIndex?: boolean; // Pad index numbers with 0, e.g. 01, 02, 03, ...
-  zeroBasedArrayIndex?: boolean; // Start array index from 0
+  disablePadIndex?: boolean; // Disables padding of array index numbers if forceIndex = true
+  zeroBasedArrayIndex?: boolean; // start array index from 0 if forceIndex = true
   channelName?: string; // Set name of the root channel.
   preferedArrayName?: string; // Set key to use this as an array entry name.
   preferedArrayDesc?: string;
@@ -57,8 +57,8 @@ class Json2iob {
    * @param {Options} [options={}] - The parsing options.
    * @param {boolean} [options.write] - Activate write for all states.
    * @param {boolean} [options.forceIndex] - Instead of trying to find names for array entries, use the index as the name.
-   * @param {boolean} [options.padArrayIndex] - Pad index numbers with 0, e.g. 01, 02, 03, ...
-   * @param {boolean} [options.zeroBasedArrayIndex] - Start array index from 0
+   * @param {boolean} [options.disablePadIndex] - Disables padding of array index numbers if forceIndex = true
+   * @param {boolean} [options.zeroBasedArrayIndex] - Start array index from 0 if forceIndex = true
    * @param {string} [options.channelName] - Set name of the root channel.
    * @param {string} [options.preferedArrayName] - Set key to use this as an array entry name.
    * @param {string} [options.preferedArrayDesc] - Set key to use this as an array entry description.
@@ -447,7 +447,7 @@ class Json2iob {
               indexNumber -= 1;
           }
 
-          index = `${(options.padArrayIndex === true || options.padArrayIndex === undefined) && indexNumber < 10 ? "0" : ""}${indexNumber}`;
+          index = `${options.disablePadIndex === false && indexNumber < 10 ? "0" : ""}${indexNumber}`;
           arrayPath = key + index;
         }
         //special case array with 2 string objects

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,7 +314,7 @@ class Json2iob {
    * @param {boolean} [options.dontSaveCreatedObjects] - If true, the created object will not be saved.
    * @returns {Promise<void>} - A promise that resolves when the state object is created.
    */
-  async _createState(path: string, common: any, options: Options = {}) {
+  async _createState(path: string, common: any, options: Options = {}): Promise<void> {
     await this.adapter
       .extendObjectAsync(path, {
         type: "state",
@@ -341,7 +341,7 @@ class Json2iob {
    * @param {object} options - The parsing options.
    * @returns {Promise<void>} - A promise that resolves when the array extraction and parsing is complete.
    */
-  async _extractArray(element: any, key: string, path: string, options: Options) {
+  async _extractArray(element: any, key: string, path: string, options: Options): Promise<void> {
     try {
       if (key) {
         element = element[key];
@@ -530,7 +530,7 @@ class Json2iob {
    * @param {string} str - The string to be checked.
    * @returns {boolean} - Returns true if the string is a valid base64 encoded string, otherwise returns false.
    */
-  _isBase64(str: string) {
+  _isBase64(str: string): boolean {
     if (!str || typeof str !== "string") {
       return false;
     }
@@ -543,7 +543,7 @@ class Json2iob {
    * @param {string} str - The string to be checked.
    * @returns {boolean} - Returns true if the string is a valid JSON string, otherwise false.
    */
-  _isJsonString(str: string) {
+  _isJsonString(str: string): boolean {
     try {
       JSON.parse(str);
     } catch (e) {
@@ -557,7 +557,7 @@ class Json2iob {
    * @param {boolean} write - Indicates whether the element is being written to.
    * @returns {string} - The role of the element.
    */
-  _getRole(element: any, write: boolean) {
+  _getRole(element: any, write: boolean): "indicator" | "switch" | "value.time" | "value" | "level" | "text" | "state" {
     if (typeof element === "boolean" && !write) {
       return "indicator";
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -447,7 +447,7 @@ class Json2iob {
               indexNumber -= 1;
           }
 
-          index = `${options.padArrayIndex === true && indexNumber < 10 ? "0" : ""}${indexNumber}`;
+          index = `${(options.padArrayIndex === true || options.padArrayIndex === undefined) && indexNumber < 10 ? "0" : ""}${indexNumber}`;
           arrayPath = key + index;
         }
         //special case array with 2 string objects

--- a/src/index.ts
+++ b/src/index.ts
@@ -444,10 +444,16 @@ class Json2iob {
 
         if (options.forceIndex) {
           if (options.zeroBasedArrayIndex === true) {
-              indexNumber -= 1;
+            indexNumber -= 1;
           }
 
-          index = `${options.disablePadIndex === false && indexNumber < 10 ? "0" : ""}${indexNumber}`;
+          if (options.disablePadIndex) {
+            index = indexNumber.toString();
+          } else if (indexNumber < 10) {
+            // reassign index in case zeroBasedarrayIndex is enabled
+            index = `0${indexNumber}`;
+          }
+
           arrayPath = key + index;
         }
         //special case array with 2 string objects

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import JSONbig from "json-bigint";
 type Options = {
   write?: boolean; // Activate write for all states.
   forceIndex?: boolean; // Instead of trying to find names for array entries, use the index as the name.
+  padArrayIndex?: boolean; // Pad index numbers with 0, e.g. 01, 02, 03, ...
+  zeroBasedArrayIndex?: boolean; // Start array index from 0
   channelName?: string; // Set name of the root channel.
   preferedArrayName?: string; // Set key to use this as an array entry name.
   preferedArrayDesc?: string;
@@ -55,6 +57,8 @@ class Json2iob {
    * @param {Options} [options={}] - The parsing options.
    * @param {boolean} [options.write] - Activate write for all states.
    * @param {boolean} [options.forceIndex] - Instead of trying to find names for array entries, use the index as the name.
+   * @param {boolean} [options.padArrayIndex] - Pad index numbers with 0, e.g. 01, 02, 03, ...
+   * @param {boolean} [options.zeroBasedArrayIndex] - Start array index from 0
    * @param {string} [options.channelName] - Set name of the root channel.
    * @param {string} [options.preferedArrayName] - Set key to use this as an array entry name.
    * @param {string} [options.preferedArrayDesc] - Set key to use this as an array entry description.
@@ -348,10 +352,11 @@ class Json2iob {
           this.adapter.log.debug("Cannot extract empty: " + path + "." + key + "." + index);
           continue;
         }
-        // @ts-ignore
-        index = parseInt(index) + 1;
-        // @ts-ignore
-        if (index < 10) {
+        
+        let indexNumber = parseInt(index) + 1;
+        index = indexNumber.toString();
+
+        if (indexNumber < 10) {
           index = "0" + index;
         }
         if (options.autoCast && typeof arrayElement === "string" && this._isJsonString(arrayElement)) {
@@ -438,6 +443,11 @@ class Json2iob {
         }
 
         if (options.forceIndex) {
+          if (options.zeroBasedArrayIndex === true) {
+              indexNumber -= 1;
+          }
+
+          index = `${options.padArrayIndex === true && indexNumber < 10 ? "0" : ""}${indexNumber}`;
           arrayPath = key + index;
         }
         //special case array with 2 string objects


### PR DESCRIPTION
# Description
Add options for

- zero based array index
- disable array index padding

# Zero based array index
`json2iob` uses 1 based indexes for arrays whereas more commonly used are zero based indexes. Setting `zeroBasedArrayIndex = true` will use zero based array indexes.

# Disable array index padding
Array indexes are padded with `0` if `index < 10`. This is visually nice but requires a little extra code when accessing array indexes programmatically by their path. Setting `disablePadIndex = true` will not pad the array indexes.