### PR TITLE
fix: wrong array index if index > 10

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -449,9 +449,9 @@ class Json2iob {
 
           if (options.disablePadIndex) {
             index = indexNumber.toString();
-          } else if (indexNumber < 10) {
+          }  else {
             // reassign index in case zeroBasedarrayIndex is enabled
-            index = `0${indexNumber}`;
+            index = `${indexNumber < 10 ? "0" : ""}${indexNumber}`;
           }
 
           arrayPath = key + index;


### PR DESCRIPTION
During refactoring and testing I discovered that there was still an issue in combination with `zeroBasedArrayIndex`. If the array index is less than 10 but `zeroBasedArrayIndex` is enabled, the index also needs to be reassign because it was decreased.

![image](https://github.com/TA2k/json2iob/assets/6503243/0dec3c77-1570-4e35-8018-c79ad41e2925)